### PR TITLE
refactor: restructure base modules to make importing easier

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,10 +1,42 @@
+import os
+import logging
+from dotenv import load_dotenv
+
 from flask import Flask
 from controllers.UserController import user_blueprint
 from controllers.PostController import post_blueprint
 from controllers.RecipeController import recipe_blueprint
 from controllers.GroupController import group_blueprint
 
+
 app = Flask(__name__)
+app.logger.setLevel(logging.INFO)
+
+if load_dotenv(os.getenv("ENV_PATH")):
+    app.logger.info(f"Loaded env from path: {os.getenv('ENV_PATH')}")
+else:
+    app.logger.warn(f"Unable to load env from path: {os.getenv('ENV_PATH')}")
+
+
+loglevel = logging.INFO
+if os.getenv("LOG_LEVEL"):
+    match os.getenv("LOG_LEVEL").lower():
+        case "debug":
+            loglevel = logging.DEBUG
+        case "info":
+            loglevel = logging.INFO
+        case "warn":
+            loglevel = logging.WARN
+        case "error":
+            loglevel = logging.ERRO
+        case "critical":
+            loglevel = logging.CRITICAL
+        case _:
+            loglevel = logging.INFO
+
+    app.logger.setLevel(loglevel)
+    del loglevel
+
 
 # Register the blueprints (controllers)
 app.register_blueprint(user_blueprint)

--- a/dtos/__init__.py
+++ b/dtos/__init__.py
@@ -1,0 +1,4 @@
+from .PostDto import PostDto as PostDto
+from .UserDto import UserDto as UserDto
+from .RecipeDto import RecipeDto as RecipeDto
+from .GroupsDto import GroupsDto as GroupsDto

--- a/repositories/BaseRepository.py
+++ b/repositories/BaseRepository.py
@@ -1,14 +1,15 @@
+from os import getenv
+
 import libsql_client as libsql
-import configparser
+
 
 class BaseRepository:
-    def __init__(self, isProd):
-        config = configparser.ConfigParser()
-        config.read("config.ini")
-        if isProd:
-            self.client = libsql.create_client_sync(
-                url=config.get('database', 'url'),
-                auth_token=config.get('database', 'auth_token')
-            )
-        else:
-            self.client = libsql.create_client_sync(url="file:scripts/recipes.db")
+    def __init__(self, isProd: bool):
+        self.client = libsql.create_client_sync(
+            url=getenv("DATABASE_URL"),
+            auth_token=getenv("DATABASE_AUTHTOKEN")
+        )
+
+    def __del__(self):
+        if self.client:
+            self.client.close()

--- a/repositories/__init__.py
+++ b/repositories/__init__.py
@@ -1,0 +1,3 @@
+from .PostRepository import PostRepository as PostRepository
+from .UserRepository import UserRepository as UserRepository
+from .BaseRepository import BaseRepository as BaseRepository

--- a/services/GroupService.py
+++ b/services/GroupService.py
@@ -1,0 +1,3 @@
+class GroupService:
+    def __init__(self):
+        pass

--- a/services/RecipeService.py
+++ b/services/RecipeService.py
@@ -1,0 +1,3 @@
+class RecipeService:
+    def __init__(self):
+        pass

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,4 @@
+from .PostService import PostService as PostService
+from .UserService import UserService as UserService
+from .RecipeService import RecipeService as RecipeService
+from .GroupService import GroupService as GroupService


### PR DESCRIPTION
Adds `__init__.py` files to re-export submodules from the root module so you can do
```py
from repositories import PostRepository
```
instead of
```py
from repositories.PostRepository import PostRepository
```

Also uses pydotenv to load app config at startup. This requires setting the `ENV_PATH` env var before running the app: `ENV_PATH=local.env flask run` or `set ENV_PATH=local.env`/`$Env:ENV_PATH="local.env"` on cmd/powershell.
